### PR TITLE
join/merge & drop empty

### DIFF
--- a/fastreshape.ado
+++ b/fastreshape.ado
@@ -8,7 +8,7 @@
 
 program define fastreshape
 version 13.1
-syntax anything, [i(string asis) j(string asis) robust fast string verbose]
+syntax anything, [i(string asis) j(string asis) robust fast string verbose drop_empty]
 
 *-------------------------------------------------------------------------------
 * Setup
@@ -427,6 +427,31 @@ if "`rtype'"=="long" {
 		foreach s in `stubs' {
 			cap rename `s'`c' `s'
 		}
+		* prepare drop
+		local drop "qui drop if "
+		local counter = 0
+		local zstubs ""
+		foreach s in `stubs' {
+			cap ds `s'
+			if _rc==0 {
+				local zstubs "`zstubs' `s'"
+			}
+		}
+		qui ds `zstubs', has(type string)
+		local sstubs = r(varlist)
+		foreach s in `sstubs' {
+			local ++counter
+			if `counter' > 1 local drop "`drop' & "
+			local drop `"`drop' `s' == "" "'
+		}
+		qui ds `zstubs', has(type numeric)
+		local nstubs = r(varlist)
+		foreach s in `nstubs' {
+			local ++counter
+			if `counter' > 1 local drop "`drop' & "
+			local drop `"`drop' missing(`s') "'
+		}
+		if "`drop_empty'" != "" `drop'
 		tempfile temp`z'
 		qui save `temp`z'', replace
 	}

--- a/fastreshape.ado
+++ b/fastreshape.ado
@@ -427,31 +427,33 @@ if "`rtype'"=="long" {
 		foreach s in `stubs' {
 			cap rename `s'`c' `s'
 		}
-		* prepare drop
-		local drop "qui drop if "
-		local counter = 0
-		local zstubs ""
-		foreach s in `stubs' {
-			cap ds `s'
-			if _rc==0 {
-				local zstubs "`zstubs' `s'"
+		if "`drop_empty'" != "" {
+			* prepare drop
+			local drop "qui drop if "
+			local counter = 0
+			local zstubs ""
+			foreach s in `stubs' {
+				cap ds `s'
+				if _rc==0 {
+					local zstubs "`zstubs' `s'"
+				}
 			}
+			qui ds `zstubs', has(type string)
+			local sstubs = r(varlist)
+			foreach s in `sstubs' {
+				local ++counter
+				if `counter' > 1 local drop "`drop' & "
+				local drop `"`drop' `s' == "" "'
+			}
+			qui ds `zstubs', has(type numeric)
+			local nstubs = r(varlist)
+			foreach s in `nstubs' {
+				local ++counter
+				if `counter' > 1 local drop "`drop' & "
+				local drop `"`drop' missing(`s') "'
+			}
+			`drop'
 		}
-		qui ds `zstubs', has(type string)
-		local sstubs = r(varlist)
-		foreach s in `sstubs' {
-			local ++counter
-			if `counter' > 1 local drop "`drop' & "
-			local drop `"`drop' `s' == "" "'
-		}
-		qui ds `zstubs', has(type numeric)
-		local nstubs = r(varlist)
-		foreach s in `nstubs' {
-			local ++counter
-			if `counter' > 1 local drop "`drop' & "
-			local drop `"`drop' missing(`s') "'
-		}
-		if "`drop_empty'" != "" `drop'
 		tempfile temp`z'
 		qui save `temp`z'', replace
 	}

--- a/fastreshape.ado
+++ b/fastreshape.ado
@@ -235,7 +235,8 @@ if "`rtype'"=="wide" {
 	if "`verbose'"!="" timer on 4
 	qui use `temp_1', clear
 	forval k=2/`num_j' {
-		cap merge 1:1 `i' using `temp_`k'', nogen
+		*cap merge 1:1 `i' using `temp_`k'', nogen
+		cap join , from(`temp_`k') by(`i') uniquemaster
 		if _rc!=0 {
 			noi di as error "Error: i (`i') not unique within j (`j')."
 			exit 1


### PR DESCRIPTION
This PR is related to #6 

fastreshape long with 153 variables (2 j variables, 3 stubs) to 6 variables, 4 million observations, some stub variables are missing for many observations (any observation can have between 1 and 149 values). I put a new argument called drop_empty which is faster and is lighter on RAM. 

   1:    155.72 /        1 =     155.7150 // my version
   2:    188.22 /        1 =     188.2250 // your version

I dont have a dataset to hand to try out the wide part though... so I dont know whether it works...